### PR TITLE
Use mysql binary prefix

### DIFF
--- a/bin/create-db
+++ b/bin/create-db
@@ -35,7 +35,8 @@ def main(target_hostname):
                                  port=host['PORT'],
                                  database_name='')
             base_engine = sqlalchemy.create_engine(
-                base_uri, listeners=[ForceStrictMode()])
+                base_uri, listeners=[ForceStrictMode()],
+                connect_args={'binary_prefix': True})
 
             schema_name = shard['SCHEMA_NAME']
             print 'Setting up database: {}'.format(schema_name)

--- a/inbox/ignition.py
+++ b/inbox/ignition.py
@@ -52,7 +52,8 @@ def engine(database_name, database_uri, pool_size=DB_POOL_SIZE,
                            pool_recycle=pool_recycle,
                            max_overflow=max_overflow,
                            connect_args={'charset': 'utf8mb4',
-                                         'waiter': gevent_waiter})
+                                         'waiter': gevent_waiter,
+                                         'binary_prefix': True})
 
     @event.listens_for(engine, 'checkout')
     def receive_checkout(dbapi_connection, connection_record,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask==0.10.1
 gevent==1.0.1
 gevent-socketio==0.3.5-rc2
 gunicorn==19.0.0
-mysqlclient==1.3.7
+mysqlclient==1.3.10
 requests==2.4.3
 chardet==2.1.1
 setproctitle==1.1.8

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "html2text>=2014.9.8",
         "pyinstrument>=0.12",
         "PyMySQL>=0.6.2",
-        "mysqlclient==1.3.7",
+        "mysqlclient==1.3.10",
         "setproctitle>=1.1.8",
         "pymongo>=2.5.2",
         "python-dateutil>=2.4",


### PR DESCRIPTION
Fixes warnings that started after upgrading MySQL from `5.6.23` to `5.6.34`.  Warnings are causing high memory and probably cpu on api/sync nodes. 

```
Warning.1300*Invalid utf8mb4 character string: 'A3261E'
```