### PR TITLE
Sort tuples so they are always in same order

### DIFF
--- a/inbox/models/when.py
+++ b/inbox/models/when.py
@@ -13,8 +13,8 @@ def parse_as_when(raw):
 
     """
     when_classes = [TimeSpan, Time, DateSpan, Date]
-    keys_for_type = {tuple(cls_.json_keys): cls_ for cls_ in when_classes}
-    given_keys = tuple(set(raw.keys()) - set('object'))
+    keys_for_type = {tuple(sorted(cls_.json_keys)): cls_ for cls_ in when_classes}
+    given_keys = tuple(sorted(set(raw.keys()) - set('object')))
     when_type = keys_for_type.get(given_keys)
     if when_type is None:
         raise ValueError("When object had invalid keys.")


### PR DESCRIPTION
This fixes what must be a race condition because the tests `test_api_timespan` and `test_api_datespan` don't always fail.  This gurantees ordering of `start_time` and `end_time` in `when` so the `.get` successfully finds the type.