### PR TITLE
Allow syncing accounts where UIDVALIDITY for non-INBOX folders changes

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -223,10 +223,10 @@ class FolderSyncEngine(Greenlet):
                                              'resync loop')
                         account.sync_state = 'stopped'
                         db_session.commit()
+                    raise MailsyncDone()
                 else:
                     self.state = 'finish'
-
-                raise MailsyncDone()
+                    self.heartbeat_status.publish(state=self.state)
 
         except FolderMissingError:
             # Folder was deleted by monitor while its sync was running.

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -154,6 +154,7 @@ class FolderSyncEngine(Greenlet):
             'initial uidinvalid': self.resync_uids,
             'poll': self.poll,
             'poll uidinvalid': self.resync_uids,
+            'finish': lambda: 'finish',
         }
 
         self.setup_heartbeats()
@@ -211,14 +212,19 @@ class FolderSyncEngine(Greenlet):
             # Check that we're not stuck in an endless uidinvalidity resync loop.
             if self.uidinvalid_count > MAX_UIDINVALID_RESYNCS:
                 log.error('Resynced more than MAX_UIDINVALID_RESYNCS in a'
-                          ' row. Stopping sync.')
+                          ' row. Stopping sync.', folder_name=self.folder_name)
 
-                with session_scope(self.namespace_id) as db_session:
-                    account = db_session.query(Account).get(self.account_id)
-                    account.disable_sync('Detected endless uidvalidity '
-                                         'resync loop')
-                    account.sync_state = 'stopped'
-                    db_session.commit()
+                # Only stop syncing the entire account if the INBOX folder is
+                # failing. Otherwise simply stop syncing the folder.
+                if self.folder_name.lower() == 'inbox':
+                    with session_scope(self.namespace_id) as db_session:
+                        account = db_session.query(Account).get(self.account_id)
+                        account.disable_sync('Detected endless uidvalidity '
+                                             'resync loop')
+                        account.sync_state = 'stopped'
+                        db_session.commit()
+                else:
+                    self.state = 'finish'
 
                 raise MailsyncDone()
 


### PR DESCRIPTION
Only stop syncing the entire account if the INBOX folder is failing. Otherwise
simply stop syncing the folder.