### PR TITLE
Add index for cursor queries

### DIFF
--- a/inbox/models/transaction.py
+++ b/inbox/models/transaction.py
@@ -23,6 +23,8 @@ class Transaction(MailSyncBase, HasPublicID):
 Index('object_type_record_id', Transaction.object_type, Transaction.record_id)
 Index('namespace_id_created_at', Transaction.namespace_id,
       Transaction.created_at)
+Index('ix_transaction_namespace_id_object_type_id', Transaction.namespace_id,
+      Transaction.object_type, Transaction.id)
 
 
 class AccountTransaction(MailSyncBase, HasPublicID):

--- a/migrations/versions/244_cursor_index.py
+++ b/migrations/versions/244_cursor_index.py
@@ -1,0 +1,23 @@
+"""Add index for cursor queries
+
+Revision ID: 2c67046c548d
+Revises: 2c47d9226de6
+Create Date: 2018-04-23 16:39:39.990250
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2c67046c548d'
+down_revision = '2c47d9226de6'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('ix_transaction_namespace_id_object_type_id', 'transaction',
+                    ['namespace_id', 'object_type', 'id'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_transaction_namespace_id_object_type_id',
+                  table_name='transaction')


### PR DESCRIPTION
This is an optimized index to handle the SQL query generated by the get cursor API request.  The SQL looks like this:

```sql
SELECT transaction.public_id AS transaction_public_id, transaction.created_at AS transaction_created_at, transaction.id AS transaction_id, transaction.namespace_id AS transaction_namespace_id, transaction.object_type AS transaction_object_type, transaction.record_id AS transaction_record_id, transaction.object_public_id AS transaction_object_public_id, transaction.command AS transaction_command 
FROM transaction ignore index (ix_transaction_namespace_id_object_type_id)
WHERE transaction.id > 117212893 AND transaction.namespace_id = 999 AND transaction.object_type NOT IN ('folder', 'metadata', 'account', 'label') ORDER BY transaction.id ASC 
LIMIT 250
```

```create index ix_transaction_namespace_id_object_type_id on transaction (namespace_id, object_type, id)```