### PR TITLE
Fix unicode error in API

### DIFF
--- a/inbox/api/validation.py
+++ b/inbox/api/validation.py
@@ -20,7 +20,7 @@ MAX_LIMIT = 1000
 class ValidatableArgument(reqparse.Argument):
 
     def handle_validation_error(self, error):
-        raise InputError(str(error))
+        raise InputError(unicode(error))
 
 
 # Custom parameter types


### PR DESCRIPTION
We'll now get a 400 error like this instead of a 500:

```
% curl -u 'X:' 'localhost:5555/threads?any_email=x@%e4.com'
{
  "message": "Invalid recipient address x@\ufffd.com",
  "type": "invalid_request_error"
}
```

I haven't tested syncing emails with punycode domains though.