### PR TITLE
Add hint for message delete queries

### DIFF
--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -305,7 +305,8 @@ def _batch_delete(engine, table, column_id_filters, account_id, throttle=False,
                 messages = list(db_session.query(Message.id, Message.data_sha256)
                                           .filter(Message.namespace_id == id_)
                                           .order_by(desc(Message.received_date))
-                                          .limit(CHUNK_SIZE))
+                                          .limit(CHUNK_SIZE)
+                                          .with_hint(Message, 'use index (ix_message_namespace_id_received_date)'))
 
             message_ids = [m[0] for m in messages]
             message_hashes = [m[1] for m in messages]

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -415,8 +415,7 @@ class SyncbackService(gevent.Greenlet):
                         ActionLog.discriminator == 'actionlog',
                         ActionLog.status == 'pending',
                         ActionLog.namespace_id == ns_id).order_by(ActionLog.id).\
-                        limit(self.fetch_batch_size).\
-                        with_hint(ActionLog, 'use index (ix_actionlog_namespace_id_status_type)')
+                        limit(self.fetch_batch_size)
                     task = self._batch_log_entries(db_session, query.all())
                     if task is not None:
                         self.task_queue.put(task)

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -415,7 +415,8 @@ class SyncbackService(gevent.Greenlet):
                         ActionLog.discriminator == 'actionlog',
                         ActionLog.status == 'pending',
                         ActionLog.namespace_id == ns_id).order_by(ActionLog.id).\
-                        limit(self.fetch_batch_size)
+                        limit(self.fetch_batch_size).\
+                        with_hint(ActionLog, 'use index (ix_actionlog_namespace_id_status_type)')
                     task = self._batch_log_entries(db_session, query.all())
                     if task is not None:
                         self.task_queue.put(task)


### PR DESCRIPTION
Under some conditions MySQL starts using bad indexes which cause performance issues.  Without this hint the select would take 90 minutes compared to under a second when using the right index.