### PR TITLE
Detect german draft folders

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -593,6 +593,7 @@ class CrispinClient(object):
             'inbox': 'inbox',
             'drafts': 'drafts',
             'draft': 'drafts',
+            u'Entwürfe': 'drafts',
             'junk': 'spam',
             'spam': 'spam',
             'archive': 'archive',


### PR DESCRIPTION
For non-gmail accounts the folder processing code uses `default_folder_map` as the first attempt to figure out the role of folders. For most English based servers this probably handles most cases. For servers that have folder names in other languages the code relies on folder flags but some imap servers don't use these flags. Therefore a common folder like Entwürfe is never given the role of `drafts`.

An alternative approach would be to create a new provider for German servers and somehow detect the German provider should be used instead of `custom`