### PR TITLE
Revert "Use object update_at for transaction created_at"

### DIFF
--- a/inbox/models/mixins.py
+++ b/inbox/models/mixins.py
@@ -142,8 +142,8 @@ class CreatedAtMixin(object):
 
 
 class UpdatedAtMixin(object):
-    updated_at = Column(DateTime, default=func.now(),
-                        onupdate=func.now(), nullable=False, index=True)
+    updated_at = Column(DateTime, default=datetime.utcnow,
+                        onupdate=datetime.utcnow, nullable=False, index=True)
 
 
 class DeletedAtMixin(object):


### PR DESCRIPTION
Reverting this now so the head of n17 is safe and we can spend more time figuring out the best approach to fix this. I think the issue we saw with old updated dates is due to this [comment](https://docs.sqlalchemy.org/en/13/orm/session_api.html#sqlalchemy.orm.session.Session.dirty) that objects are optimistically marked as dirty meaning nothing might have really changed and therefore the `updated_at` would not have changed which results in creating transactions with old create dates.

Reverts closeio/nylas#40