### PR TITLE
Fix time inconsistencies between category changes and message transac…

### DIFF
--- a/inbox/models/transaction.py
+++ b/inbox/models/transaction.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (Column, BigInteger, String, Index, Enum,
-                        inspect)
+                        inspect, func)
 from sqlalchemy.orm import relationship
 
 from inbox.models.base import MailSyncBase
@@ -76,12 +76,25 @@ def create_revisions(session):
 def create_revision(obj, session, revision_type):
     assert revision_type in ('insert', 'update', 'delete')
 
+    # If available use object dates for the transaction timestamp
+    # otherwise use DB time. This is needed because CURRENT_TIMESTAMP
+    # changes during a transaction which can lead to inconsistencies
+    # between object timestamps and the transaction timestamps.
+    if revision_type == 'delete':
+        created_at = getattr(obj, 'deleted_at', None)
+    else:
+        created_at = getattr(obj, 'updated_at', None)
+
+    if created_at is None:
+        created_at = func.now()
+
     # Always create a Transaction record -- this maintains a total ordering over
     # all events for an account.
     revision = Transaction(command=revision_type, record_id=obj.id,
                            object_type=obj.API_OBJECT_NAME,
                            object_public_id=obj.public_id,
-                           namespace_id=obj.namespace.id)
+                           namespace_id=obj.namespace.id,
+                           created_at=created_at)
     session.add(revision)
 
     # Additionally, record account-level events in the AccountTransaction --

--- a/inbox/models/transaction.py
+++ b/inbox/models/transaction.py
@@ -3,6 +3,7 @@ from sqlalchemy import (Column, BigInteger, String, Index, Enum,
 from sqlalchemy.orm import relationship
 
 from inbox.models.base import MailSyncBase
+from inbox.models.category import EPOCH
 from inbox.models.mixins import HasPublicID, HasRevisions
 from inbox.models.namespace import Namespace
 
@@ -82,6 +83,11 @@ def create_revision(obj, session, revision_type):
     # between object timestamps and the transaction timestamps.
     if revision_type == 'delete':
         created_at = getattr(obj, 'deleted_at', None)
+        # Sometimes categories are deleted explicitly which leaves
+        # their deleted_at default value, EPOCH, when the
+        # transaction is created.
+        if created_at == EPOCH:
+            created_at = func.now()
     else:
         created_at = getattr(obj, 'updated_at', None)
 


### PR DESCRIPTION
This is similar to the work I did in https://github.com/closeio/nylas/pull/40 but handles updates to categories as well as new message creation.

Some background info on category updates:
* `message` gets marked dirty by SQLA [here](https://github.com/closeio/nylas/blob/86575eea9e1d86990a9b0dcee5f05fb4ce2b4845/inbox/mailsync/backends/imap/common.py#L79-L82) when categories change due to optimistic marking as described [here](https://docs.sqlalchemy.org/en/13/orm/session_api.html#sqlalchemy.orm.session.Session.dirty).
* Nylas uses this fact to create a `message` transaction even though nothing changes in the message table. The change actually occurred in `messagecategory`.
* This broke the previous PR because we were using the `updated_at` timestamp for the message but since no SQL statement was actually issued, the `updated_at` value for the message never changed and we used a potentially very old timestamp for the transaction record.
* This doesn't really matter 

This PR creates a single timestamp [here](https://github.com/closeio/nylas/pull/42/files#diff-42dfa382fe5713552c8282de38d14863R73) and uses it for the category `created_at` and sets the `message` `updated_at` field which also triggers a real update to the message record which wasn't happening before when category changes happened. But we can now use the message `updated_at` value in the `after_flush` handler when we create the `transaction` record for the messagecategory/message update.

Potential other issues:
* Looks like we would need to do something similar for this [API update function](https://github.com/closeio/nylas/blob/86575eea9e1d86990a9b0dcee5f05fb4ce2b4845/inbox/api/update.py#L165)
* Probably need to do more research to see if other changes mark a message as dirty but doesn't result in any changes to the message record. These would still end up creating transactions with old dates.