### PR TITLE
Toggle email syncing for existing accounts

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -146,6 +146,8 @@ def create_account():
     provider = data.get('provider', 'custom')
     email_address = data['email_address']
 
+    sync_email = data.get('sync_email', True)
+
     if data['type'] == 'generic':
         auth_handler = GenericAuthHandler(provider)
         account = auth_handler.create_account(email_address, {
@@ -161,6 +163,8 @@ def create_account():
             'smtp_server_port': 25,
             'smtp_username': 'dummy',
             'smtp_password': 'dummy',
+
+            'sync_email': sync_email,
         })
 
     elif data['type'] == 'gmail':
@@ -173,6 +177,7 @@ def create_account():
             'id_token': '',
             'contacts': False,
             'events': False,
+            'sync_email': sync_email,
         })
 
     else:
@@ -190,12 +195,18 @@ def create_account():
 
 @app.route('/accounts/<namespace_public_id>/', methods=['PUT'])
 def modify_account(namespace_public_id):
-    """ Modify an existing account """
+    """
+    Modify an existing account
+
+    This stops syncing an account until it is explicitly resumed.
+    """
 
     data = request.get_json(force=True)
 
     provider = data.get('provider', 'custom')
     email_address = data['email_address']
+
+    sync_email = data.get('sync_email', True)
 
     with global_session_scope() as db_session:
         namespace = db_session.query(Namespace) \
@@ -220,6 +231,8 @@ def modify_account(namespace_public_id):
                 'smtp_server_port': 25,
                 'smtp_username': 'dummy',
                 'smtp_password': 'dummy',
+
+                'sync_email': sync_email,
             })
 
         elif isinstance(account, GmailAccount):
@@ -231,6 +244,7 @@ def modify_account(namespace_public_id):
                     'refresh_token': data['refresh_token'],
                     'scope': GOOGLE_EMAIL_SCOPE,
                     'id_token': '',
+                    'sync_email': sync_email,
                     'contacts': False,
                     'events': False,
                 })

--- a/inbox/auth/generic.py
+++ b/inbox/auth/generic.py
@@ -110,6 +110,8 @@ class GenericAuthHandler(AuthHandler):
 
         account.ssl_required = response.get('ssl_required', True)
 
+        account.sync_email = response.get('sync_email', True)
+
         # Ensure account has sync enabled after authing.
         account.enable_sync()
         return account

--- a/inbox/auth/gmail.py
+++ b/inbox/auth/gmail.py
@@ -134,8 +134,7 @@ class GmailAuthHandler(OAuthAuthHandler):
         account.locale = response.get('locale')
         account.picture = response.get('picture')
         account.home_domain = response.get('hd')
-        account.sync_email = (account.sync_email or
-                              response.get('sync_email', True))
+        account.sync_email = response.get('sync_email', True)
         account.sync_contacts = (account.sync_contacts or
                                  response.get('contacts', True))
         account.sync_events = (account.sync_events or

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -181,8 +181,21 @@ class FolderSyncEngine(Greenlet):
         # eagerly signal the sync status
         self.heartbeat_status.publish()
 
+        def start_sync(saved_folder_status):
+            sync_end_time = saved_folder_status.metrics.get('sync_end_time')
+            if sync_end_time:
+                sync_delay = datetime.utcnow() - sync_end_time
+                if sync_delay > timedelta(days=1):
+                    saved_folder_status.state = 'initial'
+                    log.info('switching to initial sync due to delay',
+                             folder_id=self.folder_id,
+                             account_id=self.account_id,
+                             sync_delay=sync_delay.total_seconds())
+
+            saved_folder_status.start_sync()
+
         try:
-            self.update_folder_sync_status(lambda s: s.start_sync())
+            self.update_folder_sync_status(start_sync)
         except IntegrityError:
             # The state insert failed because the folder ID ForeignKey
             # was no longer valid, ie. the folder for this engine was deleted
@@ -265,7 +278,8 @@ class FolderSyncEngine(Greenlet):
                 state = ImapFolderSyncStatus.state
                 saved_folder_status = db_session.query(ImapFolderSyncStatus)\
                     .filter_by(account_id=self.account_id, folder_id=self.folder_id)\
-                    .options(load_only(state)).one()
+                    .one()
+
             except NoResultFound:
                 saved_folder_status = ImapFolderSyncStatus(
                     account_id=self.account_id, folder_id=self.folder_id)

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -182,7 +182,11 @@ class FolderSyncEngine(Greenlet):
         self.heartbeat_status.publish()
 
         def start_sync(saved_folder_status):
-            sync_end_time = saved_folder_status.metrics.get('sync_end_time')
+            # Ensure we don't cause an error if the folder was deleted.
+            sync_end_time = (
+                saved_folder_status.folder and
+                saved_folder_status.metrics.get('sync_end_time')
+            )
             if sync_end_time:
                 sync_delay = datetime.utcnow() - sync_end_time
                 if sync_delay > timedelta(days=1):

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -279,7 +279,6 @@ class FolderSyncEngine(Greenlet):
         # they are never out of sync.
         with session_scope(self.namespace_id) as db_session:
             try:
-                state = ImapFolderSyncStatus.state
                 saved_folder_status = db_session.query(ImapFolderSyncStatus)\
                     .filter_by(account_id=self.account_id, folder_id=self.folder_id)\
                     .one()


### PR DESCRIPTION
- When an account is paused and resumed at a later stage, we want to put folders
back into "initial" state. This will ensure that the latest messages are synced
first, rather than oldest first. Note that this won't trigger a complete resync
of the account, it will just sync missing messages.

- Explicitly toggle sync email via API: An account can remain in Nylas without having email syncing enabled, and later resumed by the API