### PR TITLE
Sync calendar event visibility

### DIFF
--- a/inbox/api/kellogs.py
+++ b/inbox/api/kellogs.py
@@ -288,6 +288,7 @@ def _encode(obj, namespace_public_id=None, expand=False, is_n1=False):
             'when': encode(obj.when),
             'busy': obj.busy,
             'status': obj.status,
+            'visibility': obj.visibility,
         }
         if isinstance(obj, RecurringEvent):
             resp['recurrence'] = {

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -527,6 +527,8 @@ def parse_event_response(event, read_only_calendar):
     master_uid = event.get('recurringEventId')
     cancelled = (event.get('status') == 'cancelled')
 
+    visibility = event.get('visibility')
+
     return Event(uid=uid,
                  raw_data=raw_data,
                  title=title,
@@ -548,7 +550,8 @@ def parse_event_response(event, read_only_calendar):
                  cancelled=cancelled,
                  status=event_status,
                  sequence_number=sequence,
-                 source='local')
+                 source='local',
+                 visibility=visibility)
 
 
 def _dump_event(event):

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -140,6 +140,8 @@ class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin,
     # stores the version number of the invite.
     sequence_number = Column(Integer, nullable=True)
 
+    visibility = Column(Enum('private', 'public'), nullable=True)
+
     discriminator = Column('type', String(30))
     __mapper_args__ = {'polymorphic_on': discriminator,
                        'polymorphic_identity': 'event'}
@@ -278,6 +280,7 @@ class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin,
         self.last_modified = event.last_modified
         self.message = event.message
         self.status = event.status
+        self.visibility = event.visibility
 
         if event.sequence_number is not None:
             self.sequence_number = event.sequence_number

--- a/migrations/versions/247_add_event_visibility.py
+++ b/migrations/versions/247_add_event_visibility.py
@@ -1,0 +1,22 @@
+"""add visibility to event
+
+Revision ID: 53b532fda984
+Revises: 69c4b13c806
+Create Date: 2019-07-11 21:29:39.635787
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '53b532fda984'
+down_revision = '69c4b13c806'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('event', sa.Column('visibility', sa.Enum('private', 'public'), nullable=True))
+
+
+def downgrade():
+    op.drop_column('event', 'visibility')


### PR DESCRIPTION
This syncs the event visibility field, and returns it in the API. Values are:
* `public`,
* `private`,
* null, for default visibility.

I tested creating an event with a specific visibility, as well as modifying existing events, including setting visibility back to default.

I wasn't able to find any way to change the default visibility of a Google Calendar, therefore I'm not adding a `default_visibility` field to the `Calendar` model.

Before deploying:

- [x]  @jkemp101 Can we safely run the migration on production in a non-blocking way that doesn't hurt performance? E.g. we have around 450k rows in the event table on cluster A.  