### PR TITLE
Calendar webhook improvements

### DIFF
--- a/etc/config-dev.json
+++ b/etc/config-dev.json
@@ -74,7 +74,7 @@
 "ENCRYPT_SECRETS": false,
 "DEBUG_CONSOLE_ON": true,
 
-"FEATURE_FLAGS": "ical_autoimport GOOGLE_PUSH_NOTIFICATIONS",
+"FEATURE_FLAGS": "ical_autoimport",
 
 "THROTTLE_DELETION": false,
 "UMPIRE_BASE_URL": "127.0.0.1",

--- a/etc/config-dev.json
+++ b/etc/config-dev.json
@@ -74,7 +74,7 @@
 "ENCRYPT_SECRETS": false,
 "DEBUG_CONSOLE_ON": true,
 
-"FEATURE_FLAGS": "ical_autoimport",
+"FEATURE_FLAGS": "ical_autoimport GOOGLE_PUSH_NOTIFICATIONS",
 
 "THROTTLE_DELETION": false,
 "UMPIRE_BASE_URL": "127.0.0.1",

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -20,8 +20,16 @@ from inbox.events.google import GoogleEventsProvider
 
 EVENT_SYNC_FOLDER_ID = -2
 EVENT_SYNC_FOLDER_NAME = 'Events'
+
+# Update frequency for accounts without push notifications
 POLL_FREQUENCY = config.get('CALENDAR_POLL_FREQUENCY', 300)
 
+# Update frequency for accounts with push notifications (accounts are only
+# updated if there was a recent push notification).
+PUSH_NOTIFICATION_POLL_FREQUENCY = 10
+
+# How often accounts with push notifications are synced even if there was no
+# push notification.
 MAX_TIME_WITHOUT_SYNC = timedelta(seconds=3600)
 
 
@@ -193,6 +201,17 @@ def handle_event_updates(namespace_id, calendar_id, events, log, db_session):
 
 class GoogleEventSync(EventSync):
 
+    def __init__(self, *args, **kwargs):
+        super(GoogleEventSync, self).__init__(*args, **kwargs)
+        with session_scope(self.namespace_id) as db_session:
+            account = db_session.query(Account).get(self.account_id)
+            if (
+                self.provider.push_notifications_enabled(account) and
+                kwargs.get('poll_frequency') is None
+            ):
+                # Poll more frequently if push notifications are enabled.
+                self.poll_frequency = PUSH_NOTIFICATION_POLL_FREQUENCY
+
     def sync(self):
         """Query a remote provider for updates and persist them to the
         database. This function runs every `self.poll_frequency`.
@@ -261,12 +280,16 @@ class GoogleEventSync(EventSync):
     def _sync_data(self):
         with session_scope(self.namespace_id) as db_session:
             account = db_session.query(Account).get(self.account_id)
-            if account.should_update_calendars(MAX_TIME_WITHOUT_SYNC):
+            if (
+                account.should_update_calendars(
+                    MAX_TIME_WITHOUT_SYNC, timedelta(seconds=POLL_FREQUENCY))
+            ):
                 self._sync_calendar_list(account, db_session)
 
             stale_calendars = (
                 cal for cal in account.namespace.calendars
-                if cal.should_update_events(MAX_TIME_WITHOUT_SYNC)
+                if cal.should_update_events(MAX_TIME_WITHOUT_SYNC,
+                                            timedelta(seconds=POLL_FREQUENCY))
             )
             for cal in stale_calendars:
                 try:

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -209,7 +209,10 @@ class GoogleEventSync(EventSync):
                 self.provider.push_notifications_enabled(account) and
                 kwargs.get('poll_frequency') is None
             ):
-                # Poll more frequently if push notifications are enabled.
+                # Run the sync loop more frequently if push notifications are
+                # enabled. Note that we'll only update the calendar if a
+                # Webhook was receicved recently, or if we haven't synced for
+                # too long.
                 self.poll_frequency = PUSH_NOTIFICATION_POLL_FREQUENCY
 
     def sync(self):

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -285,6 +285,7 @@ class GmailAccount(OAuthAccount, ImapAccount):
         # Google gives us back expiration timestamps in milliseconds
         expiration = datetime.fromtimestamp(int(expiration) / 1000.)
         self.gpush_calendar_list_expiration = expiration
+        self.gpush_calendar_list_last_ping = datetime.utcnow()
 
     def handle_gpush_notification(self):
         self.gpush_calendar_list_last_ping = datetime.utcnow()

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -289,21 +289,26 @@ class GmailAccount(OAuthAccount, ImapAccount):
     def handle_gpush_notification(self):
         self.gpush_calendar_list_last_ping = datetime.utcnow()
 
-    def should_update_calendars(self, max_time_between_syncs):
+    def should_update_calendars(self, max_time_between_syncs, poll_frequency):
         """
         max_time_between_syncs: a timedelta object. The maximum amount of
         time we should wait until we sync, even if we haven't received
         any push notifications
 
+        poll_frequency: a timedelta object. Amount of time we should wait until
+        we sync if we don't have working push notifications.
         """
+        now = datetime.utcnow()
         return (
             # Never synced
             self.last_calendar_list_sync is None or
             # Too much time has passed to not sync
-            (datetime.utcnow() >
-                self.last_calendar_list_sync + max_time_between_syncs) or
-            # Push notifications channel is stale
-            self.needs_new_calendar_list_watch() or
+            (now > self.last_calendar_list_sync + max_time_between_syncs) or
+            # Push notifications channel is stale (and we didn't just sync it)
+            (
+                self.needs_new_calendar_list_watch()
+                now > self.last_synced + poll_frequency
+            ) or
             # Our info is stale, according to google's push notifications
             (
                 self.gpush_calendar_list_last_ping is not None and

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -306,8 +306,8 @@ class GmailAccount(OAuthAccount, ImapAccount):
             (now > self.last_calendar_list_sync + max_time_between_syncs) or
             # Push notifications channel is stale (and we didn't just sync it)
             (
-                self.needs_new_calendar_list_watch()
-                now > self.last_synced + poll_frequency
+                self.needs_new_calendar_list_watch() and
+                now > self.last_calendar_list_sync + poll_frequency
             ) or
             # Our info is stale, according to google's push notifications
             (

--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -83,11 +83,14 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin,
             self.gpush_expiration < datetime.utcnow()
         )
 
-    def should_update_events(self, max_time_between_syncs):
+    def should_update_events(self, max_time_between_syncs, poll_frequency):
         """
         max_time_between_syncs: a timedelta object. The maximum amount of
         time we should wait until we sync, even if we haven't received
         any push notifications
+
+        poll_frequency: a timedelta object. Amount of time we should wait until
+        we sync if we don't have working push notifications.
         """
         if self.name == 'Emailed events':
             return False
@@ -95,13 +98,18 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin,
         if 'group.v.calendar.google.com' in self.uid:
             return False  # maybe?
 
+        now = datetime.utcnow()
+
         return (
             # Never synced
             self.last_synced is None or
-            # Push notifications channel is stale
-            self.needs_new_watch() or
+            # Push notifications channel is stale (and we didn't just sync it)
+            (
+                self.needs_new_watch() and
+                now > self.last_synced + poll_frequency
+            ) or
             # Too much time has passed not to sync
-            datetime.utcnow() > self.last_synced + max_time_between_syncs or
+            now > self.last_synced + max_time_between_syncs or
             # Events are stale, according to the push notifications
             (
                 self.gpush_last_ping is not None and

--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -62,6 +62,7 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin,
         """
         expiration = datetime.fromtimestamp(int(expiration) / 1000.)
         self.gpush_expiration = expiration
+        self.gpush_last_ping = datetime.utcnow()
 
     def handle_gpush_notification(self):
         self.gpush_last_ping = datetime.utcnow()

--- a/inbox/test/webhooks/test_gpush_calendar_notifications.py
+++ b/inbox/test/webhooks/test_gpush_calendar_notifications.py
@@ -60,35 +60,35 @@ def test_should_update_logic(db, watched_account, watched_calendar):
 
     ten_minutes = timedelta(minutes=10)
     # Never synced - should update
-    assert watched_account.should_update_calendars(ten_minutes)
-    assert watched_calendar.should_update_events(ten_minutes)
+    assert watched_account.should_update_calendars(ten_minutes, 0)
+    assert watched_calendar.should_update_events(ten_minutes, 0)
 
     five_minutes_ago = datetime.utcnow() - timedelta(minutes=5)
     watched_account.last_calendar_list_sync = five_minutes_ago
     watched_calendar.last_synced = five_minutes_ago
-    assert not watched_account.should_update_calendars(ten_minutes)
-    assert not watched_calendar.should_update_events(ten_minutes)
+    assert not watched_account.should_update_calendars(ten_minutes, 0)
+    assert not watched_calendar.should_update_events(ten_minutes, 0)
 
     four_minutes = timedelta(minutes=4)
-    assert watched_account.should_update_calendars(four_minutes)
-    assert watched_calendar.should_update_events(four_minutes)
+    assert watched_account.should_update_calendars(four_minutes, 0)
+    assert watched_calendar.should_update_events(four_minutes, 0)
 
     watched_account.handle_gpush_notification()
     watched_calendar.handle_gpush_notification()
-    assert watched_account.should_update_calendars(ten_minutes)
-    assert watched_calendar.should_update_events(ten_minutes)
+    assert watched_account.should_update_calendars(ten_minutes, 0)
+    assert watched_calendar.should_update_events(ten_minutes, 0)
 
     watched_account.last_calendar_list_sync = datetime.utcnow()
     watched_calendar.last_synced = datetime.utcnow()
 
-    assert not watched_account.should_update_calendars(ten_minutes)
-    assert not watched_calendar.should_update_events(ten_minutes)
+    assert not watched_account.should_update_calendars(ten_minutes, 0)
+    assert not watched_calendar.should_update_events(ten_minutes, 0)
 
     # If watch is expired, should always update
     watched_account.new_calendar_list_watch(WATCH_EXPIRATION)
     watched_calendar.new_event_watch(WATCH_EXPIRATION)
-    assert watched_account.should_update_calendars(ten_minutes)
-    assert watched_calendar.should_update_events(ten_minutes)
+    assert watched_account.should_update_calendars(ten_minutes, 0)
+    assert watched_calendar.should_update_events(ten_minutes, 0)
 
 
 def test_needs_new_watch_logic(db, watched_account, watched_calendar):

--- a/inbox/test/webhooks/test_gpush_calendar_notifications.py
+++ b/inbox/test/webhooks/test_gpush_calendar_notifications.py
@@ -172,7 +172,7 @@ def test_calendar_update(db, webhooks_client, watched_account):
     calendar_path = CALENDAR_LIST_PATH.format(watched_account.public_id)
 
     before = datetime.utcnow() - timedelta(seconds=1)
-    assert watched_account.gpush_calendar_list_last_ping is None
+    watched_account.gpush_calendar_list_last_ping = datetime(2010, 1, 1)
 
     headers = UPDATE_HEADERS.copy()
     headers['X-Goog-Channel-Id'] = ACCOUNT_WATCH_UUID
@@ -199,7 +199,7 @@ def test_event_update(db, webhooks_client, watched_calendar):
     event_path = CALENDAR_PATH.format(watched_calendar.public_id)
 
     before = datetime.utcnow() - timedelta(seconds=1)
-    assert watched_calendar.gpush_last_ping is None
+    watched_calendar.gpush_last_ping = datetime(2010, 1, 1)
 
     headers = UPDATE_HEADERS.copy()
     headers['X-Goog-Channel-Id'] = CALENDAR_WATCH_UUID

--- a/inbox/webhooks/gpush_notifications.py
+++ b/inbox/webhooks/gpush_notifications.py
@@ -86,16 +86,6 @@ def event_update(calendar_public_id):
             calendar = db_session.query(Calendar) \
                 .filter(Calendar.public_id == calendar_public_id) \
                 .one()
-            if calendar.gpush_last_ping is not None:
-                time_since_last_ping = (
-                    datetime.utcnow() - calendar.gpush_last_ping
-                ).total_seconds()
-
-                # Limit write volume, and de-herd, in case we're getting many
-                # concurrent updates for the same calendar.
-                if time_since_last_ping < 10 + random.randrange(0, 10):
-                    return resp(200)
-
             calendar.handle_gpush_notification()
             db_session.commit()
         return resp(200)


### PR DESCRIPTION
- Update Webhook-enabled calendars within 10s of a Webhook being posted (and every hour if there are no Webhooks being posted), and update non-Webhook enabled calendars every 5 minutes.
- For now, don't throttle Webhooks since it may result in calendars not being synced properly.
