### PR TITLE
Disable sync if one of the enabled features fails

### DIFF
--- a/inbox/models/account.py
+++ b/inbox/models/account.py
@@ -238,13 +238,8 @@ class Account(MailSyncBase, HasPublicID, HasEmailAddress, HasRunState,
         after trying to re-authorize / get new token.
 
         """
-        if scope == 'calendar':
-            self.sync_events = False
-        elif scope == 'contacts':
-            self.sync_contacts = False
-        else:
-            self.disable_sync(reason)
-            self.sync_state = 'invalid'
+        self.disable_sync(reason)
+        self.sync_state = 'invalid'
 
     def mark_for_deletion(self):
         """


### PR DESCRIPTION
We should not silently disable syncing events or contacts if it fails. Since
there isn't currently a good way to keep track of feature-specific failures,
this commit will disable syncing the entire account regardless of which feature
is failing.