### PR TITLE
Fix namespace deletion

### DIFF
--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -183,7 +183,7 @@ def delete_namespace(namespace_id, throttle=False, dry_run=False):
 
     filters = OrderedDict()
     for table in ['message', 'block', 'thread', 'transaction', 'actionlog',
-                  'contact', 'event', 'dataprocessingcache']:
+                  'event', 'contact', 'dataprocessingcache']:
         filters[table] = ('namespace_id', namespace_id)
 
     if account_discriminator == 'easaccount':


### PR DESCRIPTION
Tested locally. Previously, deleting a namespace with events would fail with
```
IntegrityError: (_mysql_exceptions.IntegrityError) (1451, 'Cannot delete or update a parent row: a foreign key constraint fails (`inbox`.`eventcontactassociation`, CONSTRAINT `eventcontactassociation_ibfk_1` FOREIGN KEY (`contact_id`) REFERENCES `contact` (`id`))') [SQL: 'DELETE FROM contact WHERE namespace_id=23 LIMIT 100;']
```
With the fix, the deletion was successful.