### PR TITLE
Empty body on 204

### DIFF
--- a/inbox/webhooks/gpush_notifications.py
+++ b/inbox/webhooks/gpush_notifications.py
@@ -28,7 +28,11 @@ def resp(http_code, message=None, **kwargs):
     resp = kwargs
     if message:
         resp['message'] = message
-    return make_response(jsonify(resp), http_code)
+    if http_code == 204:
+        body = ''
+    else:
+        body = jsonify(resp)
+    return make_response(body, http_code)
 
 
 @app.before_request


### PR DESCRIPTION
Don't try to send `{}` with a 204 (No Content). It triggers AssertionError (500) on Google's "sync" messages

> After creating a new notification channel to watch a resource, the Google Calendar API sends a sync message to indicate that notifications are starting. The X-Goog-Resource-State HTTP header value for these messages is sync. Because of network timing issues, it is possible to receive the sync message even before you receive the watch method response.
> It is safe to ignore the sync notification, but you can also make use of it.

https://developers.google.com/calendar/v3/push