### PR TITLE
Rate limit Google webhook calls

### DIFF
--- a/inbox/ignition.py
+++ b/inbox/ignition.py
@@ -1,6 +1,8 @@
+import limitlion
 import time
 import weakref
 import gevent
+import redis
 from socket import gethostname
 from urllib import quote_plus as urlquote
 from sqlalchemy import create_engine, event
@@ -229,3 +231,15 @@ def reset_invalid_autoincrements(engine, schema, key, dry_run=True):
                     engine.execute(reset_query)
                 reset.add(str(table))
     return reset
+
+
+# Probably not the best place for this but for now
+# we are using limitlion to protect the DBs so we
+# should be able to assume this will be loaded
+# before a DB is accessed.
+redis_limitlion = redis.Redis(
+    config.get("THROTTLE_REDIS_HOSTNAME"),
+    int(config.get("REDIS_PORT")),
+    db=config.get("THROTTLE_REDIS_DB"),
+)
+limitlion.throttle_configure(redis_limitlion)

--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -7,11 +7,8 @@ from collections import OrderedDict
 from sqlalchemy import desc
 from sqlalchemy.orm.exc import NoResultFound
 
-import redis
-
 import limitlion
 
-from inbox.config import config
 from inbox.models import Account, Block, Message, Namespace
 from inbox.util.blockstore import delete_from_blockstore
 from inbox.util.stats import statsd_client
@@ -28,12 +25,8 @@ CHUNK_SIZE = 100
 
 log = get_logger()
 
-# Use a single Redis instance for rate limiting.  Limits will be applied across
-# all db shards (same approach as the original check_throttle()).
-redis_limitlion = redis.Redis(config.get('THROTTLE_REDIS_HOSTNAME'),
-                              int(config.get('REDIS_PORT')),
-                              db=config.get('THROTTLE_REDIS_DB'))
-limitlion.throttle_configure(redis_limitlion)
+# Use a single throttle instance for rate limiting.  Limits will be applied
+# across all db shards (same approach as the original check_throttle()).
 bulk_throttle = limitlion.throttle_wait('bulk', rps=.75, window=5)
 
 


### PR DESCRIPTION
Tested locally by running curl multiple times. Once it hits the throttle limit the `invalid_request_error` error stops getting returned until the rate limit expires.

```
curl -X POST -H "X-Goog-Channel-ID: 1" -H "X-Goog-Resource-State: 1" -H "X-Goog-Resource-ID: 1" http://127.0.0.1:5555/calendar_update/785cfu32fwnoq09vql8lmg68
```

Also, ran `bin/purge-transaction-log --days-ago 30 --throttle` to confirm that throttle still works.