### PR TITLE
Updated README.md: Development moved to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **NOTE: Work on sync-engine has been moved to https://github.com/closeio/sync-engine.**
 
+
 The Nylas Sync Engine provides a RESTful API on top of a powerful email sync platform, making it easy to build apps on top of email. See the [full API documentation](https://www.nylas.com/docs/) for more details.
 
 Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nylas Sync Engine [![Build Status](https://travis-ci.org/nylas/sync-engine.svg?branch=master)](https://travis-ci.org/nylas/sync-engine)
 
+**NOTE: Work on sync-engine has been moved to https://github.com/closeio/sync-engine.**
+
 The Nylas Sync Engine provides a RESTful API on top of a powerful email sync platform, making it easy to build apps on top of email. See the [full API documentation](https://www.nylas.com/docs/) for more details.
 
 Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Nylas Sync Engine provides a RESTful API on top of a powerful email sync pla
 
 Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)
 
-
+   
 ### Installation and Setup
 
 1. Install the latest versions of [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Install Vagrant](http://www.vagrantup.com/downloads.html).


### PR DESCRIPTION
Development will now happen in https://github.com/closeio/sync-engine.

For reference, see https://github.com/closeio/nylas/issues/79.